### PR TITLE
Conditionally compile os-specific bits of termios under Linux and OSX

### DIFF
--- a/src/termios.rs
+++ b/src/termios.rs
@@ -1,26 +1,134 @@
-use libc::{c_int, c_uchar, c_uint};
+use libc::{c_int, c_uchar};
+
+pub use self::os::{
+    B0, B50, B75, B110, B134, B150, B200, B300, B600, B1200, B1800, B2400, B4800, B9600, B19200,
+    B38400, B57600, B115200, B230400, CRTSCTS, CS5, CS6, CS7, CS8, CSIZE, CSTOPB, IXOFF, IXON,
+    NCCS, PARODD, VMIN, VTIME, speed_t,
+};
+
+#[cfg(target_os = "linux")]
+pub use self::os::{
+    B460800, B500000, B576000, B921600, B1000000, B1152000, B1500000, B2000000, B2500000, B3000000,
+    B3500000, B4000000
+};
+
+#[cfg(target_os = "macos")]
+pub use self::os::{B7200, B14400, B28800, B76800};
+
+use self::os::tcflag_t;
 
 #[allow(non_camel_case_types)]
-pub type speed_t = c_uint;
-#[allow(non_camel_case_types)]
-type cc_t = c_uchar;
-#[allow(non_camel_case_types)]
-type tcflag_t = c_uint;
+pub type cc_t = c_uchar;
 
-pub static CRTSCTS: tcflag_t = 0x80000000;
-pub static CSIZE: tcflag_t = 0x30;
-pub static CSTOPB: tcflag_t = 0x40;
 pub static FAILURE: c_int = -1;
 pub static IXANY: tcflag_t = 0x0800;
-pub static IXOFF: tcflag_t = 0x1000;
-pub static IXON: tcflag_t = 0x0400;
-pub static NCCS: c_int = 32;
-pub static PARENB: tcflag_t = 0x0100;
-pub static PARODD: tcflag_t = 0x0200;
+pub static PARENB: tcflag_t = 0x1000;
 pub static SUCCESS: c_int = 0;
 pub static TCSANOW: c_int = 0;
-pub static VMIN: cc_t = 6;
-pub static VTIME: cc_t = 5;
+
+#[cfg(target_os = "linux")]
+mod os {
+    use libc::c_uint;
+    use super::cc_t;
+
+    #[allow(non_camel_case_types)]
+    pub type speed_t = c_uint;
+    #[allow(non_camel_case_types)]
+    pub type tcflag_t = c_uint;
+
+    pub static B0: speed_t = 0x00;
+    pub static B1000000: speed_t = 0x1008;
+    pub static B110: speed_t = 0x03;
+    pub static B1152000: speed_t = 0x1009;
+    pub static B115200: speed_t = 0x1002;
+    pub static B1200: speed_t = 0x09;
+    pub static B134: speed_t = 0x04;
+    pub static B1500000: speed_t = 0x100A;
+    pub static B150: speed_t = 0x05;
+    pub static B1800: speed_t = 0x0A;
+    pub static B19200: speed_t = 0x0E;
+    pub static B2000000: speed_t = 0x100B;
+    pub static B200: speed_t = 0x06;
+    pub static B230400: speed_t = 0x1003;
+    pub static B2400: speed_t = 0x0B;
+    pub static B2500000: speed_t = 0x100C;
+    pub static B3000000: speed_t = 0x100D;
+    pub static B300: speed_t = 0x07;
+    pub static B3500000: speed_t = 0x100E;
+    pub static B38400: speed_t = 0x0F;
+    pub static B4000000: speed_t = 0x100F;
+    pub static B460800: speed_t = 0x1004;
+    pub static B4800: speed_t = 0x0C;
+    pub static B500000: speed_t = 0x1005;
+    pub static B50: speed_t = 0x01;
+    pub static B576000: speed_t = 0x1006;
+    pub static B57600: speed_t = 0x1001;
+    pub static B600: speed_t = 0x08;
+    pub static B75: speed_t = 0x02;
+    pub static B921600: speed_t = 0x1007;
+    pub static B9600: speed_t = 0x0D;
+    pub static CRTSCTS: tcflag_t = 0x80000000;
+    pub static CS5: tcflag_t = 0x00;
+    pub static CS6: tcflag_t = 0x10;
+    pub static CS7: tcflag_t = 0x20;
+    pub static CS8: tcflag_t = 0x30;
+    pub static CSIZE: tcflag_t = 0x30;
+    pub static CSTOPB: tcflag_t = 0x40;
+    pub static IXOFF: tcflag_t = 0x1000;
+    pub static IXON: tcflag_t = 0x0400;
+    pub static NCCS: uint = 32;
+    pub static PARODD: tcflag_t = 0x0200;
+    pub static VMIN: cc_t = 6;
+    pub static VTIME: cc_t = 5;
+}
+
+#[cfg(target_os = "macos")]
+mod os {
+    use libc::c_ulong;
+    use super::cc_t;
+
+    #[allow(non_camel_case_types)]
+    pub type speed_t = c_ulong;
+    #[allow(non_camel_case_types)]
+    pub type tcflag_t = c_ulong;
+
+    pub static B0: speed_t = 0;
+    pub static B110: speed_t = 110;
+    pub static B115200: speed_t = 115200;
+    pub static B1200: speed_t = 1200;
+    pub static B134: speed_t = 134;
+    pub static B14400: speed_t = 14400;
+    pub static B150: speed_t = 150;
+    pub static B1800: speed_t = 1800;
+    pub static B19200: speed_t = 19200;
+    pub static B200: speed_t = 200;
+    pub static B230400: speed_t = 230400;
+    pub static B2400: speed_t = 2400;
+    pub static B28800: speed_t = 28800;
+    pub static B300: speed_t = 300;
+    pub static B38400: speed_t = 38400;
+    pub static B4800: speed_t = 4800;
+    pub static B50: speed_t = 50;
+    pub static B57600: speed_t = 57600;
+    pub static B600: speed_t = 600;
+    pub static B7200: speed_t = 7200;
+    pub static B75: speed_t = 75;
+    pub static B76800: speed_t = 76800;
+    pub static B9600: speed_t = 9600;
+    pub static CRTSCTS: tcflag_t = 0x020000 | 0x040000;
+    pub static CS5: tcflag_t = 0x0000;
+    pub static CS6: tcflag_t = 0x0100;
+    pub static CS7: tcflag_t = 0x0200;
+    pub static CS8: tcflag_t = 0x0300;
+    pub static CSIZE: tcflag_t = 0x0300;
+    pub static CSTOPB: tcflag_t = 0x0400;
+    pub static IXOFF: tcflag_t = 0x0400;
+    pub static IXON: tcflag_t = 0x0200;
+    pub static NCCS: uint = 20;
+    pub static PARODD: tcflag_t = 0x2000;
+    pub static VMIN: cc_t = 16;
+    pub static VTIME: cc_t = 17;
+}
 
 #[repr(C)]
 pub struct Termios {
@@ -28,21 +136,36 @@ pub struct Termios {
     c_oflag: tcflag_t,
     pub c_cflag: tcflag_t,
     c_lflag: tcflag_t,
-    c_line: cc_t,
-    pub c_cc: [cc_t, ..NCCS as uint],
+    #[cfg(target_os = "linux")] c_line: cc_t,
+    pub c_cc: [cc_t, ..NCCS],
     pub c_ispeed: speed_t,
     pub c_ospeed: speed_t,
 }
 
+// TODO (rust-lang/rust#7622) Remove the `new()` method, make `Termios` derive the `Default` trait
 impl Termios {
+    #[cfg(target_os = "linux")]
     pub fn new() -> Termios {
         Termios {
-            c_cc: [0, ..NCCS as uint],
+            c_cc: [0, ..NCCS],
             c_cflag: 0,
             c_iflag: 0,
             c_ispeed: 0,
             c_lflag: 0,
             c_line: 0,
+            c_oflag: 0,
+            c_ospeed: 0,
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn new() -> Termios {
+        Termios {
+            c_cc: [0, ..NCCS],
+            c_cflag: 0,
+            c_iflag: 0,
+            c_ispeed: 0,
+            c_lflag: 0,
             c_oflag: 0,
             c_ospeed: 0,
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,7 +7,7 @@ use {
         BothDirections, Input, Output,
     BaudRate,
         B0, B50, B75, B110, B134, B150, B200, B300, B600, B1K2, B2K4, B4K8, B9K6, B19K2, B38K4,
-        B57K6, B115K2, B230K4, B460K8, B500K, B921K6, B1M, B1M152, B1M5, B2M, B2M5, B3M, B3M5, B4M,
+        B57K6, B115K2, B230K4,
     //DataBits,
         Data5, Data6, Data7, Data8,
     //FlowControl,
@@ -17,11 +17,25 @@ use {
     //StopBits,
         Stop1, Stop2,
 };
+
+#[cfg(target_os = "linux")]
+use {B460K8, B500K, B576K, B921K6, B1M, B1M152, B1M5, B2M, B2M5, B3M, B3M5, B4M};
+
+#[cfg(target_os = "macos")]
+use {B7K2, B14K4, B28K8, B76K8};
+
 use socat::Socat;
 
+#[cfg(target_os = "linux")]
 static BAUD_RATES: &'static [BaudRate] = &[
     B0, B50, B75, B110, B134, B150, B200, B300, B600, B1K2, B2K4, B4K8, B9K6, B19K2, B38K4, B57K6,
-    B115K2, B230K4, B460K8, B500K, B921K6, B1M, B1M152, B1M5, B2M, B2M5, B3M, B3M5, B4M];
+    B115K2, B230K4, B460K8, B500K, B576K, B921K6, B1M, B1M152, B1M5, B2M, B2M5, B3M, B3M5, B4M];
+
+#[cfg(target_os = "macos")]
+static BAUD_RATES: &'static [BaudRate] = &[
+    B0, B50, B75, B110, B134, B150, B200, B300, B600, B1K2, B2K4, B4K8, B7K2, B9K6, B14K4, B19K2,
+    B28K8, B38K4, B57K6, B115K2, B230K4];
+
 static MESSAGE: &'static str = "Hello World!";
 
 #[test]


### PR DESCRIPTION
cc @gitfoxi

I expect this won't work in my first attempt, so please report all the compilation/test errors (preferably via gist snippets if they are too long) or any other issue you find here.

Note that you'll need [socat](http://www.dest-unreach.org/socat) to run the test suite. I think you can install it using homebrew.
