### PR TITLE
Tested against osx 10.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A serial port library on top of the termios API
 - A libc that includes the termios API.
   - Tested against glibc-2.15 on Ubuntu 12.04. (See travis)
   - Tested against glibc-2.20 on some [obscure][exherbo] Linux distro.
+  - Tested against OSX 10.9
 - `socat`, used to create virtual serial ports, only required to run the tests.
 
 # License


### PR DESCRIPTION
I looked to see what version of libc OSX uses and apparently Apple is a bit cagey about it. There's this in the library header, but I don't think it means much to the outside world:

```
  cmd LC_SOURCE_VERSION
  cmdsize 16
  version 1197.1.1
```

`sys/termios.h` says

> Copyright (c) 2000-2006 Apple Computer, Inc. All rights reserved.

So it's probably compatible at-least with any OSX version that Rust can run on.
